### PR TITLE
Enhance FAQ and add admin section

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>لوحة الإدارة - نور الحوزة</title>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Cairo',sans-serif;background:#f7f7f7;color:#333;padding:2rem;text-align:center;}
+    form{background:#fff;padding:2rem;border-radius:8px;display:inline-block;box-shadow:0 4px 12px rgba(0,0,0,0.1);}
+    label{display:block;margin-bottom:.5rem;font-weight:600;}
+    input{padding:.5rem .8rem;width:100%;margin-bottom:1rem;border:1px solid #ccc;border-radius:4px;}
+    button{padding:.5rem 1rem;background:#054a29;color:#fff;border:none;border-radius:4px;cursor:pointer;}
+    button:hover{background:#0a6b3e;}
+    #questions{margin-top:2rem;text-align:right;}
+    #questions li{background:#fff;margin-bottom:.5rem;padding:.5rem;border-radius:4px;box-shadow:0 2px 6px rgba(0,0,0,0.05);}
+  </style>
+</head>
+<body>
+  <form id="loginForm">
+    <label for="password">كلمة المرور:</label>
+    <input type="password" id="password" required>
+    <button type="submit">دخول</button>
+  </form>
+  <ul id="questions" hidden></ul>
+<script>
+const form=document.getElementById('loginForm');
+const list=document.getElementById('questions');
+form.addEventListener('submit',async e=>{
+  e.preventDefault();
+  const password=document.getElementById('password').value;
+  const res=await fetch('/admin/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({password})});
+  if(res.ok){
+    form.style.display='none';
+    list.hidden=false;
+    loadQuestions();
+  }else{alert('كلمة المرور غير صحيحة');}
+});
+async function loadQuestions(){
+  const res=await fetch('/admin/questions');
+  if(!res.ok)return alert('فشل جلب الأسئلة');
+  const data=await res.json();
+  list.innerHTML='';
+  data.forEach(q=>{
+    const li=document.createElement('li');
+    li.textContent=`${q.date.slice(0,10)}: ${q.question}`;
+    list.appendChild(li);
+  });
+}
+</script>
+</body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -102,21 +102,183 @@
     </section>
     <div class="accordion">
       <div class="item">
-        <div class="header"><span><i class="fas fa-bolt"></i> ما هو الهدف من مشروع "نور الحوزة"؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="header"><span><i class="fas fa-circle-question"></i> ١. من هو نموذج نور الحوزة؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
         <div class="body">
-          <p>يطمح المشروع إلى تسهيل الوصول إلى علوم أهل البيت عليهم السلام، وتقديم محتوى موثوق بأسلوب معاصر يخدم طلبة العلم والباحثين.</p>
+          <p>هو نظام حواري معرفي بأسلوب حوزوي، يعتمد فقط على المصادر الإمامية المعتبرة لخدمة الطالب والباحث في علوم الشريعة والعقيدة والأخلاق.</p>
         </div>
       </div>
       <div class="item">
-        <div class="header"><span><i class="fas fa-shield-alt"></i> هل يعتمد الموقع على مصادر موثوقة؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="header"><span><i class="fas fa-book"></i> ٢. ما هي المصادر التي يعتمد عليها؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
         <div class="body">
-          <p>نعم، نعتمد حصراً على المصادر المعتمدة في المدرسة الإمامية الإثني عشرية، سواء في التفسير أو الفقه أو العقيدة.</p>
+          <p>يعتمد على القرآن بتفسير أهل البيت عليهم السلام، وعلى الكتب الأربعة وبحار الأنوار، وكتب الفقه والعقيدة المعروفة، إضافة إلى المواقع الشيعية الرسمية.</p>
         </div>
       </div>
       <div class="item">
-        <div class="header"><span><i class="fas fa-user-edit"></i> كيف يمكنني إرسال سؤال غير موجود هنا؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="header"><span><i class="fas fa-users"></i> ٣. من هو صانع هذا النموذج؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
         <div class="body">
-          <p>يمكنك استخدام النموذج أدناه لإرسال سؤالك، وسيجري تخزينه لدراسة الإجابة المناسبة وإضافتها لاحقاً.</p>
+          <p>قام بصنعه فريق علمائي صغير من مملكة البحرين لخدمة الحوزة وطلابها دون أي أهداف تجارية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-certificate"></i> ٤. هل يصدر عن المرجعية الدينية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>المشروع مستقل عن المكاتب المرجعية لكنه ملتزم بخط المرجعية وينقل الفتاوى بحذر مع توصية بمراجعة الرسائل العملية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-bullseye"></i> ٥. ما هي أهدافه؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>تيسير طلب العلم، إرشاد السائلين، الرد على الشبهات، نشر الثقافة الرسالية، ومرافقة الشباب تربوياً وأخلاقياً.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-handshake"></i> ٦. كيف يتعامل مع المسائل الخلافية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يعرض الأقوال الفقهية مع مستنداتها ويرجح رأي المشهور، ويذكر الآراء المخالفة للتقريب والنقد البناء.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-ban"></i> ٧. هل يستخدم اجتهاده الشخصي؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يمتنع كلياً عن الاجتهاد أو التفسير بالرأي، وينقل فقط أقوال أهل البيت والعلماء الثقات.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-check-double"></i> ٨. كيف يضبط صحة الأحاديث والفتاوى؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يذكر مصدر كل حديث ودرجة اعتباره، ويبين طريق الجمع أو الترجيح بحسب علم الرجال والدراية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-question"></i> ٩. هل يجيب عن كل سؤال؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يجيب عما يدخل ضمن دائرة العلم المعتبر ويتحفظ عن الغيبيات، ويعتذر عند الجهل ويوصي بمراجعة المختصين.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-lightbulb"></i> ١٠. هل بإمكانه الرد على الشبهات؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>نعم، يعتمد الأدلة النقلية والعقلية ويدافع عن مذهب أهل البيت عليهم السلام بأسلوب علمي رصين.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-child"></i> ١١. ما أسلوبه مع الشباب والمراهقين؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يستخدم لغة مبسطة ويقرب المفاهيم بالأمثلة والقصص مع نصائح عملية أخلاقية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-sync-alt"></i> ١٢. هل يتعامل مع المسائل المستحدثة؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>نعم، يستند إلى أحدث فتاوى المراجع المنشورة ويوصي بمراجعة المرجع في كل مسألة جديدة.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-hand-holding-heart"></i> ١٣. كيف يتعامل مع المخالفين والملحدين؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يجادل بالتي هي أحسن ويركز على المشترك من القرآن والعقل دون تشنج أو إساءة.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-external-link-alt"></i> ١٤. هل ينقل عن مصادر غير شيعية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>لا ينقل إلا عند الحاجة للاحتجاج أو النقد، ولا يعتمد تلك المصادر في بيان العقيدة أو الفقه.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-robot"></i> ١٥. هل يعتمد على الذكاء الاصطناعي الغربي؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>كلا، يعتمد حصراً على المصادر الحوزوية ولا يستخدم بيانات أو آراء من خارجها.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-user-graduate"></i> ١٦. كيف يتعامل مع طلبة الحوزة وطلاب الجامعات؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يخاطب كل فئة بحسب مستواها فيبسط للمبتدئ ويعمق للمتبحر ويستشهد بكلام العلماء والأمثال الحوزوية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-gavel"></i> ١٧. هل يجيز لنفسه إصدار الأحكام القطعية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يمتنع عن القطع في المسائل التي لا دليل فيها ويعتبر إجاباته استرشادية لا فتوى نهائية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-balance-scale"></i> ١٨. هل يتأثر بالضغوط السياسية أو الاجتماعية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>المشروع مستقل تماماً ولا يخضع لأي إملاءات سياسية أو اجتماعية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-globe"></i> ١٩. كيف يراعي التفاوت الثقافي والجغرافي؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يشرح الأحكام بما يناسب أحوال السائل ومرجعه مع مراعاة اختلاف البيئات.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-dove"></i> ٢٠. هل يدعو للعنف أو الطائفية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يدعو للوحدة والرحمة وينبذ الفتن والصراعات عملاً بوصايا أهل البيت عليهم السلام.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-microphone"></i> ٢١. هل يعتمد أسلوب الوعظ العملي؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>نعم، يربط النصيحة بسيرة النبي وآله ويقدم توجيهات عملية أخلاقية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-user-tie"></i> ٢٢. هل يمكن أن يحل محل العلماء؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>لا يمكن أن يكون بديلاً عن العلماء والمجتهدين بل هو أداة مساعدة للوصول إلى الكنوز العلمية.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-lock"></i> ٢٣. هل يحفظ بيانات المستخدمين؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يحفظ سرية السائلين ولا يستغل بياناتهم لأي غرض تجاري.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-exclamation-triangle"></i> ٢٤. كيف يواجه الأخطاء أو النقص؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يعترف بالخطأ عند ظهوره ويحث على مراجعة المصادر والعلماء للتأكد.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-book-open"></i> ٢٥. هل يمكنه تزويد السائل بالمصادر؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يذكر المصدر الكامل مع الجزء والصفحة ويقتبس النصوص بدقة ويشرحها.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-network-wired"></i> ٢٦. هل يعمل عبر الإنترنت أم بشكل مستقل؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>هو خدمة معرفية على الإنترنت تعتمد على المكتبات والمصادر الرقمية الموثوقة.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-user-plus"></i> ٢٧. هل يساهم في تربية الملكات العلمية؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>نعم، يحفز الطالب على السؤال والبحث ويزوده بقواعد المنهج العلمي.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-comments"></i> ٢٨. هل يقبل النقد والتصحيح؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>المشروع متواضع أمام أهل العلم ويطلب النقد والتصحيح دوماً.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-heart"></i> ٢٩. كيف ينصح السائلين؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يوصيهم بتقوى الله وبذل الجهد في طلب العلم ومصاحبة الصالحين ويحذر من الشبهات.</p>
+        </div>
+      </div>
+      <div class="item">
+        <div class="header"><span><i class="fas fa-star"></i> ٣٠. كيف يمكن تقييم النموذج؟</span><span class="icon"><i class="fas fa-chevron-down"></i></span></div>
+        <div class="body">
+          <p>يوفر روابط للتقييم والتقويم عبر الاستبيان والموقع الرسمي ويشجع على إبلاغ الفريق بأي خلل.</p>
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0"
+        "dotenv": "^16.3.1",
+        "express": "^5.1.0",
+        "express-session": "^1.17.3"
       }
     },
     "node_modules/accepts": {
@@ -148,6 +150,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -263,6 +277,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -529,6 +583,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -582,6 +645,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -795,6 +867,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-session": "^1.17.3",
+    "dotenv": "^16.3.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,17 @@
+require('dotenv').config();
 const express = require('express');
+const session = require('express-session');
 const fs = require('fs');
 const path = require('path');
 
 const app = express();
 app.use(express.json());
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'secret',
+  resave: false,
+  saveUninitialized: false
+}));
+app.use(express.static(__dirname));
 
 const DATA_FILE = path.join(__dirname, 'data', 'questions.json');
 
@@ -35,6 +43,22 @@ app.post('/api/questions', (req, res) => {
 app.get('/api/questions', (_req, res) => {
   const questions = loadQuestions();
   res.json(questions);
+});
+
+app.post('/admin/login', (req, res) => {
+  const { password } = req.body;
+  if (password === process.env.ADMIN_PASSWORD) {
+    req.session.authenticated = true;
+    return res.json({ message: 'Logged in' });
+  }
+  res.status(401).json({ error: 'Invalid password' });
+});
+
+app.get('/admin/questions', (req, res) => {
+  if (!req.session.authenticated) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  res.json(loadQuestions());
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- overhaul FAQ with thirty detailed answers and question form
- set up admin login page
- store submitted questions in JSON via Express server
- add session-based admin auth
- include express-session and dotenv dependencies

## Testing
- `npm install`
- `node server.js` *(server runs on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_6867ed8f8810832188211345420b5e22